### PR TITLE
Port to mainline kernel MPTCP mechanism (protocol = IPPROTO_MPTCP)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,23 +5,17 @@ CFLAGS = -fPIC -Wall -Wextra -O2 -g # C flags
 LDFLAGS = -shared  -ldl # linking flags
 RM = rm -f  # rm command
 TARGET_LIB = libmptcpmode.so # target lib
-MPTCPON = mptcp-on
-MPTCPOFF = mptcp-off
-MPTCPONSRC = mptcp-on.in
-MPTCPOFFSRC = mptcp-off.in
+MPTCPRUN = mptcp-run
+MPTCPRUNSRC = mptcp-run.in
 SRCS = mptcp_mode.c
 OBJS = $(SRCS:.c=.o)
 #
 .PHONY: all
-all: ${TARGET_LIB} ${MPTCPON} ${MPTCPOFF}
+all: ${TARGET_LIB} ${MPTCPRUN}
 
-$(MPTCPON):
-	cp ${MPTCPONSRC} ${MPTCPON}
-	chmod +x ${MPTCPON}
-
-$(MPTCPOFF):
-	cp ${MPTCPOFFSRC} ${MPTCPOFF}
-	chmod +x ${MPTCPOFF}
+$(MPTCPRUN):
+	cp ${MPTCPRUNSRC} ${MPTCPRUN}
+	chmod +x ${MPTCPRUN}
 
 $(TARGET_LIB): $(OBJS)
 	$(CC) ${LDFLAGS} -o $@ $^
@@ -33,5 +27,5 @@ $(SRCS:.c=.d):%.d:%.c
 
 .PHONY: clean
 clean:
-	-${RM} ${TARGET_LIB} ${MPTCPON} ${MPTCPOFF} ${OBJS} $(SRCS:.c=.d)
+	-${RM} ${TARGET_LIB} ${MPTCPRUN} ${OBJS} $(SRCS:.c=.d)
 

--- a/README.md
+++ b/README.md
@@ -1,40 +1,22 @@
 # mptcp-mode
-Program to enable/disable MPTCP for existing (binary) applications in Linux.
+Program to enable MPTCP for existing (binary) applications in Linux.
 
 ## description
 
-This software enables/disables MPTCP for TCP applications without having to
-recompile them. The enabling/disabling is done through a `LD_PRELOAD` which
-replaces the `socket` system call with the following:
-
-	strcpy(env_buff, getenv("LD_PRELOAD_MPTCPMODE"));
-
-	if(strcmp("on", env_buff) == 0)
-		enable = 1;
-
-	if (((PF_INET == domain) || (PF_INET6 == domain))
-	    && (SOCK_STREAM == type)) {
-
-		fd = (std_socket)(domain, type, protocol);
-		setsockopt(fd, SOL_TCP, MPTCP_ENABLED, &enable, sizeof(enable));
-
-		return fd;
-	}
+This software enables MPTCP for TCP applications without having to
+recompile them. This is done through a `LD_PRELOAD` which
+changes the protocol in `socket` calls before passing them on to the actual
+libc.
 
 Thus, using this software gives the same effect as if the application developer
-would have implemented this socket option selection. The motivation for this
+would have selected MPTCP themselves. The motivation for this
 application is simply that it enables an easy "MPTCP-switch" for proprietary
 closed-source software and for situations where you're just too lazy to change
 the code...
 
 ## usage
 
-Compile the software using `make` and use one of the two programs to turn on/off
+Compile the software using `make` and use this program to turn on
 MPTCP. For example:
 
-	./mptcp-on wget http://www.google.com
-
-or
-	
-	./mptcp-off wget http://www.google.com
-
+	./mptcp-run wget http://www.google.com

--- a/mptcp-on.in
+++ b/mptcp-on.in
@@ -1,4 +1,0 @@
-#!/bin/sh
-export LD_PRELOAD=./libmptcpmode.so
-export LD_PRELOAD_MPTCPMODE=on
-exec "$@"

--- a/mptcp-run.in
+++ b/mptcp-run.in
@@ -1,4 +1,3 @@
 #!/bin/sh
 export LD_PRELOAD=./libmptcpmode.so
-export LD_PRELOAD_MPTCPMODE=off
 exec "$@"

--- a/mptcp_mode.c
+++ b/mptcp_mode.c
@@ -35,7 +35,7 @@ int socket(int domain, int type, int protocol)
 {
     _mptcpmode_load();
 
-    if (((PF_INET == domain) || (PF_INET6 == domain))
+    if (((IPPROTO_TCP == protocol) || (0 == protocol))
         && (SOCK_STREAM == type)) {
 
 #ifdef DEBUG

--- a/mptcp_mode.c
+++ b/mptcp_mode.c
@@ -7,10 +7,6 @@
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 
-#ifndef MPTCP_ENABLED
-#define MPTCP_ENABLED 42
-#endif
-
 #define EXIT_ERROR  (1)
 
 int (*std_socket)(int domain, int type, int protocol);
@@ -37,24 +33,15 @@ void _mptcpmode_load()
 
 int socket(int domain, int type, int protocol)
 {
-    int enable = 0;
-    int fd;
-    char env_buff[256];
-
     _mptcpmode_load();
-
-    strcpy(env_buff, getenv("LD_PRELOAD_MPTCPMODE"));
-
-    if(strcmp("on", env_buff) == 0)
-        enable = 1;
 
     if (((PF_INET == domain) || (PF_INET6 == domain))
         && (SOCK_STREAM == type)) {
 
-        fd = (std_socket)(domain, type, protocol);
-        setsockopt(fd, IPPROTO_TCP, MPTCP_ENABLED, &enable, sizeof(enable));
-
-        return fd;
+#ifdef DEBUG
+        fprintf(stderr, "info: Set proto from %d to %d\n", protocol, IPPROTO_MPTCP);
+#endif
+        protocol = IPPROTO_MPTCP;
     }
 
     return (std_socket)(domain, type, protocol);


### PR DESCRIPTION
When MPTCP was put into mainline Linux, a different approach of enabling MPTCP was taken.

This takes the decision mechanism of [1](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/getting-started-with-multipath-tcp_configuring-and-managing-networking) (a systap script bending socket calls to use IPPROTO_MPTCP) into the existing framework of this LD_PRELOAD tool.

As it's now more about enabling MPTCP than about setting a flag on or off, build system and documentation have been adjusted to a single `./mptcp-run` command to replace the previous on/off ones.